### PR TITLE
Add fetchImpl option to allow users to use fetch

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -19,6 +19,7 @@ export const createClient = ({
   adapter = undefined,
   retryOnError = true,
   retryLimit = 3,
+  fetchImpl = undefined,
 }: CreateClientParams) => {
   if (!spaceUid) throw new Error('spaceUid parameter is required.')
   if (!token) throw new Error('token parameter is required.')
@@ -31,9 +32,10 @@ export const createClient = ({
 
   const baseUrl = new URL(`https://${spaceUid}.${apiType}.newt.so`)
 
+  const headers = { Authorization: `Bearer ${token}` }
   const axiosInstance = axios.create({
     baseURL: baseUrl.toString(),
-    headers: { Authorization: `Bearer ${token}` },
+    headers,
     adapter,
   })
   if (retryOnError) {
@@ -62,11 +64,20 @@ export const createClient = ({
       url.search = encoded
     }
 
-    try {
-      const { data } = await axiosInstance.get(url.pathname + url.search)
+    if (fetchImpl) {
+      const response = await fetchImpl(url, { headers })
+      if (!response.ok) {
+        throw new Error('Response invalid.')
+      }
+      const data = await response.json()
       return data
-    } catch (err) {
-      return errorHandler(err)
+    } else {
+      try {
+        const { data } = await axiosInstance.get(url.pathname + url.search)
+        return data
+      } catch (err) {
+        return errorHandler(err)
+      }
     }
   }
 
@@ -89,11 +100,20 @@ export const createClient = ({
       url.search = encoded
     }
 
-    try {
-      const { data } = await axiosInstance.get(url.pathname + url.search)
+    if (fetchImpl) {
+      const response = await fetchImpl(url, { headers })
+      if (!response.ok) {
+        throw new Error('Response invalid.')
+      }
+      const data = await response.json()
       return data
-    } catch (err) {
-      return errorHandler(err)
+    } else {
+      try {
+        const { data } = await axiosInstance.get(url.pathname + url.search)
+        return data
+      } catch (err) {
+        return errorHandler(err)
+      }
     }
   }
 
@@ -115,11 +135,20 @@ export const createClient = ({
   const getApp = async ({ appUid }: GetAppParams): Promise<AppMeta> => {
     if (!appUid) throw new Error('appUid parameter is required.')
     const url = new URL(`/v1/space/apps/${appUid}`, baseUrl.toString())
-    try {
-      const { data } = await axiosInstance.get<AppMeta>(url.pathname)
+    if (fetchImpl) {
+      const response = await fetchImpl(url, { headers })
+      if (!response.ok) {
+        throw new Error('Response invalid.')
+      }
+      const data = await response.json()
       return data
-    } catch (err) {
-      return errorHandler(err)
+    } else {
+      try {
+        const { data } = await axiosInstance.get<AppMeta>(url.pathname)
+        return data
+      } catch (err) {
+        return errorHandler(err)
+      }
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface CreateClientParams {
   adapter?: AxiosAdapter
   retryOnError?: boolean
   retryLimit?: number
+  fetchImpl?: typeof fetch
 }
 
 export interface Client {


### PR DESCRIPTION
@y-meguro 

CloudFlare Workerの内部ではaxiosを使用することができないため、例えばSvelteKitをadapter-cloudflareを使用してCloudFlare Pagesにデプロイすると、SSRが実行される時にAxiosErrorが送出されてしまう。
一方でCloudFlare WorkerではWeb fetchは問題なく使用できるため、このライブラリがHTTPリクエストを行う際にWeb fetchを使用できるような機能を実装することで、CloudFlare Workerなどの環境でもこのライブラリは正常に実行できるようになると考えられる。

本PRの変更は、createClient関数にfetchImplオプションを追加することで、ユーザーがAxiosやいくつか存在するfetch（Web fetchやnode-fetch）の中から好きな実装を選んでこのライブラリに使用させることを可能にするものである。
現状ではcreateClient関数はAxios特有のオプションを指定できるようになっているため、Axiosを完全に置き換えるのではなく選択肢としてfetchの活用を追加する方が望ましいと判断した。

以上、この変更の取り込みについて検討をお願いします。
