### PR TITLE
chore: explicitly disable install scripts in .yarnrc.yml

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,7 @@
 nodeLinker: node-modules
 
+enableScripts: false
+
 npmMinimalAgeGate: "5d"
 
 npmPreapprovedPackages: []


### PR DESCRIPTION
## 概要

`.yarnrc.yml` に `enableScripts: false` を明示的に追加し、依存パッケージの install スクリプトをプロジェクト単体で全面無効化します。

これまではグローバルの yarn 設定に依存していましたが、リポジトリ内で明示することで、環境に依存せず一貫した挙動になります。

## 変更内容

- `.yarnrc.yml` に `enableScripts: false` を追加

## 背景・効果

- 依存の `postinstall` 等の install スクリプト実行をデフォルトで無効化（サプライチェーン対策の強化）
- ビルドが本当に必要なパッケージは `package.json` の `dependenciesMeta` で `built: true` を個別指定してオプトインする運用
- 現状この依存ツリーには install スクリプトを持つパッケージが無いため、ビルドへの影響はなし

## 検証

- `yarn install --immutable` 成功
- `yarn config enableScripts` の Source がプロジェクトの `.yarnrc.yml` / Value が `false` であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)